### PR TITLE
Codable conformance and computed properties expansion exclusion

### DIFF
--- a/Sources/SimpleCodable/SimpleCodable.swift
+++ b/Sources/SimpleCodable/SimpleCodable.swift
@@ -2,5 +2,6 @@
 // https://docs.swift.org/swift-book
 
 
+@attached(extension, conformances: Codable)
 @attached(member, names: named(init), named(CodingKeys), named(encode))
 public macro Codable() = #externalMacro(module: "SimpleCodableMacros", type: "CodableMacro")


### PR DESCRIPTION
Automatically adds class extension to add protocol conformance.
`@Codable class Foo {}` will make it conform to `Codable` protocol automatically via extension : 
`extension Foo: Codable {}`
Will also exclude computed properties from expansion. (#1)
Resolves #1 